### PR TITLE
Link the Lingo

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@
 **Plan**
 
 1. We are designing a website and social media channels in order to disseminate information about the problem, the current state of research and discussion about it, as well as our approach:
-2. We are developing an opinion on what measures (such as offsetting, certicates, ...) seem appropriate. Then we motivate Bitcoin stakeholders (hodlers, miners, exchanges, businesses, etc.) to donate to providers of such measures.
+2. We are developing an opinion on what measures (such as offsetting, certicates, ...) seem appropriate. Then we motivate Bitcoin stakeholders ([hodlers](https://en.wikipedia.org/wiki/Hodl), miners, exchanges, businesses, etc.) to donate to providers of such measures.
 3. We publicly account for how much was donated, how much CO2 is offset by that, and what fraction that is of Bitcoin's estimated CO2 output - measured in time from the genesis block on. We do this while protecting the privacy of anonymous donors on one hand, as well as helping public donors use their contribution for PR on the other.
 
 ## If you want to help


### PR DESCRIPTION
While this looks like a typo, it actually is a technical term (as I learned in #1).

In order to improve the lives of others and to be a little more inclusive, link to the explanation I was pointed to.

While not being as confident as the first time around, I am still motivated to do my little part in this endeavour. I went with an inline-link instead of a listed reference as the whole page is subject to change anyway. If this part is kept, it still stays intact. Also, reuse of that link in the document is rather limited :-)